### PR TITLE
remove subscribe to package, since there is no package

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,8 +10,7 @@ class aws_agent::service inherits aws_agent {
       }
       'RedHat': {
         service { $aws_agent::service_name:
-          ensure    => running,
-          subscribe => Package['aws_agent'],
+          ensure    => running,          
           require   => Class['aws_agent::install'],
         }
       }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,8 +10,8 @@ class aws_agent::service inherits aws_agent {
       }
       'RedHat': {
         service { $aws_agent::service_name:
-          ensure    => running,          
-          require   => Class['aws_agent::install'],
+          ensure  => running,
+          require => Class['aws_agent::install'],
         }
       }
       default: {


### PR DESCRIPTION
It's installed from a script, the installation is not a package anyway and it's a one shot, no need to subscribe if require is specified.